### PR TITLE
Explicitly depend on aws-sdk-v1

### DIFF
--- a/asg-fleet.gemspec
+++ b/asg-fleet.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "aws-asg-fleet"
-  spec.version       = "0.0.5"
+  spec.version       = "0.0.6"
   spec.authors       = ["Zach Wily"]
   spec.email         = ["zach@zwily.com"]
   spec.description   = %q{AWS Auto Scaling Fleets}
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "~> 1.12"
+  spec.add_dependency "aws-sdk-v1", "~> 1.65"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
In order for projects using this gem to be able to mix the aws-sdk-v1
and aws-sdk (v2) gems, update asg-fleet.gemspec to explicitly require
aws-sdk-v1 ~> 1.65 instead of aws-sdk ~> 1.12.
